### PR TITLE
Fix format auto-detection from URL with params

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import fs from 'fs';
 import { buildQueryString } from './utils';
+import UploadResult from './upload_result';
 import Error from './error';
 
 export default class Client {
@@ -73,9 +74,10 @@ export default class Client {
       headers,
       data: stream,
       timeout: this.api.uploadTimeout * 1000,
-    }).then(response => response.data.FileId).catch((error) => {
-      throw new Error(error);
-    });
+    }).then(response => new UploadResult(response.data))
+      .catch((error) => {
+        throw new Error(error);
+      });
   }
 
   url(path) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import path from 'path';
 import pkg from '../package.json';
 import Task from './task';
 import Client from './client';
-import UploadResult from './upload_result';
 import { getReadableStream } from './utils';
 
 class ConvertAPI {
@@ -30,9 +29,8 @@ class ConvertAPI {
   async upload(source, fileName = null) {
     const resolvedFileName = fileName || path.basename(source);
     const stream = getReadableStream(source);
-    const fileId = await this.client.upload(stream, resolvedFileName);
 
-    return new UploadResult(fileId, resolvedFileName);
+    return this.client.upload(stream, resolvedFileName);
   }
 }
 

--- a/src/upload_result.js
+++ b/src/upload_result.js
@@ -1,7 +1,8 @@
 export default class UploadResult {
-  constructor(fileId, fileName) {
-    this.fileId = fileId;
-    this.fileName = fileName;
+  constructor(result) {
+    this.fileId = result.FileId;
+    this.fileName = result.FileName;
+    this.fileExt = result.FileExt;
   }
 
   toString() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import url from 'url';
 import querystring from 'querystring';
 import fs from 'fs';
 import stream from 'stream';
@@ -60,7 +61,9 @@ export const detectFormat = (params) => {
     resource = resource.fileName;
   }
 
-  return path.extname(resource).substring(1);
+  const { pathname } = url.parse(resource);
+
+  return path.extname(pathname).substring(1);
 };
 
 export const buildQueryString = (params) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -58,7 +58,7 @@ export const detectFormat = (params) => {
   }
 
   if (resource instanceof UploadResult) {
-    resource = resource.fileName;
+    return resource.fileExt;
   }
 
   const { pathname } = url.parse(resource);

--- a/test/index.js
+++ b/test/index.js
@@ -60,7 +60,7 @@ describe('ConvertAPI', () => {
   });
 
   it ('should convert file url to pdf', async () => {
-    const params = { File: 'https://www.w3.org/TR/PNG/iso_8859-1.txt' };
+    const params = { File: 'https://cdn.convertapi.com/cara/testfiles/document.docx?test=1' };
     const result = await api.convert('pdf', params);
 
     expect(result.file.url).to.be.a('string');


### PR DESCRIPTION
@tomasr78 @JonasJasas 

Issue: https://github.com/ConvertAPI/convertapi-node/issues/3

Also added improvement to use uploaded `FileExt` instead of auto-detecting uploaded file format from file name.