### PR TITLE
Expose async jobId

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,9 @@ export interface ResultFile {
 }
 
 export interface Result {
+  readonly response: object;
   readonly conversionCost: number;
+  readonly jobId?: string;
   readonly file: ResultFile;
   readonly files: [ResultFile];
   saveFiles(path: string): Promise<[string]>;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.8.0",
   "description": "Official convertapi.com API client",
   "main": "./lib/index.js",
-  "types": "./src/index.d.js",
+  "types": "./index.d.js",
   "scripts": {
     "clean": "rimraf lib",
     "test": "npm run lint && npm run cover",

--- a/src/result.js
+++ b/src/result.js
@@ -10,12 +10,17 @@ export default class Result {
     return this.response.ConversionCost;
   }
 
+  get jobId() {
+    return this.response.JobId;
+  }
+
   get file() {
     return this.files[0];
   }
 
   get files() {
-    return this.response.Files.map(file => new ResultFile(this.api, file));
+    const list = this.response.Files || [];
+    return list.map(file => new ResultFile(this.api, file));
   }
 
   async saveFiles(path) {


### PR DESCRIPTION
Will expose `jobId` of async jobs.

https://github.com/ConvertAPI/convertapi-node/issues/31