### PR TITLE
Handle multiple file params

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,10 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 20
           - 18
           - 14
           - 10
-          - 6
     name: Node ${{ matrix.node-version }} sample
     steps:
       - uses: actions/checkout@v3

--- a/src/task.js
+++ b/src/task.js
@@ -31,11 +31,12 @@ const Task = class {
 
   async normalizeParams(params) {
     const result = Object.assign({}, params, this.defaultParams);
+    const fileParams = Object.keys(params).filter(key => key.endsWith('File') && key !== 'StoreFile');
 
-    if (params.File) {
-      const file = await params.File;
-      result.File = await buildFileParam(this.api, file);
-    }
+    await Promise.all(fileParams.map(async (key) => {
+      const file = await params[key];
+      result[key] = await buildFileParam(this.api, file);
+    }));
 
     if (params.Files) {
       const files = await normalizeFilesParam(params.Files);

--- a/test/index.js
+++ b/test/index.js
@@ -119,6 +119,17 @@ describe('ConvertAPI', () => {
     expect(result.file.url).to.be.a('string');
   });
 
+  it('should compare files', async () => {
+    const params = {
+      File: './examples/files/test.docx',
+      CompareFile: './examples/files/test.docx',
+    };
+
+    const result = await api.convert('compare', params);
+
+    expect(result.file.url).to.be.a('string');
+  });
+
   it('should handle api errors', () => {
     const params = { Url: 'https://www.w3.org/TR/PNG/iso_8859-1.txt' };
 


### PR DESCRIPTION
Will treat all params ending with `File` as files except for `StoreFile`.

Fixes: https://github.com/ConvertAPI/convertapi-node/issues/60