### PR TITLE
Enable keepalive by default with an option to disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ var convertapi = require('convertapi')('your-api-secret', {
       username: 'testuser',
       password: 'secret'
     }
-  }
+  },
+  keepAlive: true
 });
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ export interface Options {
   downloadTimeout?: number;
   proxy?: object;
   baseUri?: string;
+  keepAlive?: boolean;
 }
 
 export interface ResultFile {

--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import fs from 'fs';
+import https from 'https';
 import { buildQueryString, encodeFileName } from './utils';
 import UploadResult from './upload_result';
 import Error from './error';
@@ -91,6 +92,7 @@ export default class Client {
       maxBodyLength: Infinity,
       timeout: this.api.uploadTimeout * 1000,
       proxy: this.api.proxy,
+      httpsAgent: new https.Agent({ keepAlive: this.api.keepAlive }),
     };
 
     return axios(options)

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ function ConvertAPI(secret, options = {}) {
   this.downloadTimeout = options.downloadTimeout || 1800;
   this.userAgent = `ConvertAPI-Node/${pkg.version}`;
   this.proxy = options.proxy;
+  this.keepAlive = options.keepAlive !== undefined ? options.keepAlive : true;
 
   this.client = new Client(this);
 }


### PR DESCRIPTION
Enabled https keep alive by default. Can override with an option `keepAlive`.

Attempt to fix occasional `socket hang up` errors
https://github.com/ConvertAPI/convertapi-node/issues/68